### PR TITLE
Support Unity 2022

### DIFF
--- a/Packages/com.nekometer.esnya.inari-udon/Editor/EditorTools/UdonList.cs
+++ b/Packages/com.nekometer.esnya.inari-udon/Editor/EditorTools/UdonList.cs
@@ -75,10 +75,18 @@ namespace InariUdon.EditorTools
                 listView.selectionType = SelectionType.Multiple;
                 listView.style.flexGrow = 1.0f;
 
+#if UNITY_2022_3_OR_NEWER
+                listView.selectionChanged += objects =>
+                {
+                    Selection.objects = objects.Select(o => (o as UdonBehaviour)?.gameObject).Where(o => o != null).ToArray();
+                };          
+#else
                 listView.onSelectionChanged += objects =>
                 {
                     Selection.objects = objects.Select(o => (o as UdonBehaviour)?.gameObject).Where(o => o != null).ToArray();
                 };
+#endif
+
                 Add(listView);
 
                 UpdateToolbarText();

--- a/Packages/com.nekometer.esnya.inari-udon/Editor/EditorTools/UdonPrefabTools.cs
+++ b/Packages/com.nekometer.esnya.inari-udon/Editor/EditorTools/UdonPrefabTools.cs
@@ -10,6 +10,7 @@ using VRC.Udon;
 using VRC.Udon.Common.Interfaces;
 using VRC.Udon.Serialization.OdinSerializer;
 using Object = UnityEngine.Object;
+using SerializationUtility = VRC.Udon.Serialization.OdinSerializer.SerializationUtility;
 
 namespace InariUdon.EditorTools
 {


### PR DESCRIPTION
Changes
- Use `ListView.selectionChanged` instead of `listView.onSelectionChanged` in Unity 2022.3 or newer version since `listView.onSelectionChanged was removed in Unity 2022.
- Unity 2022 have a `UnityEditor.SerializationUtility` too, so add using command to make sure it's using `VRC.Udon.Serialization.OdinSerializer.SerializationUtility`