### PR TITLE
Add UdonSharp linter CI, Codex Cloud environment and setup script

### DIFF
--- a/.codex/environment.yml
+++ b/.codex/environment.yml
@@ -1,0 +1,5 @@
+name: inariudon-codex-cloud
+setup:
+  - bash .codex/setup.sh
+checks:
+  - export DOTNET_ROOT="$HOME/.dotnet" && export PATH="$DOTNET_ROOT:$HOME/.dotnet/tools:$PATH" && udonsharp-lint Packages/com.nekometer.esnya.inari-udon

--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOTNET_DIR="${DOTNET_DIR:-$HOME/.dotnet}"
+
+if [ ! -x "$DOTNET_DIR/dotnet" ]; then
+  curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
+  bash /tmp/dotnet-install.sh --channel 8.0 --install-dir "$DOTNET_DIR"
+fi
+
+# UdonSharpLinter requires Microsoft.NETCore.App 6.0 runtime.
+if ! compgen -G "$DOTNET_DIR/shared/Microsoft.NETCore.App/6.0.*" > /dev/null; then
+  curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
+  bash /tmp/dotnet-install.sh --channel 6.0 --runtime dotnet --install-dir "$DOTNET_DIR"
+fi
+
+export DOTNET_ROOT="$DOTNET_DIR"
+export PATH="$DOTNET_ROOT:$HOME/.dotnet/tools:$PATH"
+
+if ! command -v udonsharp-lint >/dev/null 2>&1; then
+  dotnet tool install --global tktco.UdonSharpLinter --version 0.3.1
+fi
+
+echo "DOTNET_ROOT=$DOTNET_ROOT"
+dotnet --info >/dev/null
+dotnet tool list --global | grep -q tktco.udonsharplinter

--- a/.github/workflows/udonsharp-lint.yml
+++ b/.github/workflows/udonsharp-lint.yml
@@ -16,12 +16,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-dotnet@v4
+      - name: Setup .NET (SDK 8 + Runtime 6)
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: |
+            8.0.x
+            6.0.x
 
       - name: Install UdonSharp Linter
-        run: dotnet tool install -g tktco.UdonSharpLinter --version 0.3.1
+        run: dotnet tool install --global tktco.UdonSharpLinter --version 0.3.1
 
       - name: Run UdonSharp Linter
-        run: dotnet tool run udonsharp-lint Packages/com.nekometer.esnya.inari-udon
+        run: ~/.dotnet/tools/udonsharp-lint Packages/com.nekometer.esnya.inari-udon

--- a/README.md
+++ b/README.md
@@ -13,3 +13,52 @@ Do you looking for Udon Sun Controller ? This package does not contains them. It
 
 ![image](https://user-images.githubusercontent.com/2088693/180705211-f0f25559-d66f-460c-aede-445a230ae87a.png)
 ![image](https://user-images.githubusercontent.com/2088693/180705244-5dea9e3b-62a0-4ed5-b12d-89e612f49ecc.png)
+
+## CI for UdonSharp (feasible on GitHub-hosted runners)
+Because this repository is a UPM package (not a full Unity project), the practical CI method is **static check with UdonSharp linter**.
+
+### What this repository runs
+1. Install .NET 8 SDK and .NET 6 runtime (`actions/setup-dotnet`)
+2. Install `tktco.UdonSharpLinter` as a global dotnet tool
+3. Run `udonsharp-lint` against `Packages/com.nekometer.esnya.inari-udon`
+
+### Local reproduction
+```bash
+# 1) Install .NET SDK 8.x and .NET Runtime 6.x first
+# (UdonSharpLinter depends on Microsoft.NETCore.App 6.0)
+
+# 2) Install linter
+dotnet tool install --global tktco.UdonSharpLinter --version 0.3.1
+
+# 3) If dotnet was installed into a custom location, export runtime path
+export DOTNET_ROOT="$HOME/.dotnet"
+export PATH="$DOTNET_ROOT:$HOME/.dotnet/tools:$PATH"
+
+# 4) Run lint
+udonsharp-lint Packages/com.nekometer.esnya.inari-udon
+```
+
+### About Test / Build
+Running Unity Test Runner or full build requires a host Unity project and Unity license/secrets in CI, so they are intentionally not part of this workflow.
+
+
+### Alternative install (network-enabled env)
+If `dotnet` is not preinstalled, you can bootstrap it with the official installer script:
+
+```bash
+curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
+bash /tmp/dotnet-install.sh --channel 8.0 --install-dir "$HOME/.dotnet"
+bash /tmp/dotnet-install.sh --channel 6.0 --runtime dotnet --install-dir "$HOME/.dotnet"
+
+export DOTNET_ROOT="$HOME/.dotnet"
+export PATH="$DOTNET_ROOT:$HOME/.dotnet/tools:$PATH"
+```
+
+
+### Codex Cloud development environment
+For Codex Cloud tasks, this repository now includes environment files:
+- `.codex/environment.yml`
+- `.codex/setup.sh`
+
+These scripts bootstrap dotnet (SDK 8 + runtime 6) and install `UdonSharpLinter` so cloud tasks can run lint immediately.
+


### PR DESCRIPTION
### Motivation

- Provide an automated static check for the UPM package using the UdonSharp linter since a full Unity build/test is impractical in this repo.
- Make it easy to run the same lint checks in Codex Cloud by shipping environment/setup artifacts.

### Description

- Add a GitHub Actions workflow `udonsharp-lint.yml` that installs .NET SDK 8 and .NET Runtime 6, installs `tktco.UdonSharpLinter` and runs `udonsharp-lint` against `Packages/com.nekometer.esnya.inari-udon`.
- Add `.codex/environment.yml` and `.codex/setup.sh` to bootstrap a cloud development environment that installs .NET (SDK 8 + runtime 6) and the `UdonSharpLinter` tool, and exposes `DOTNET_ROOT`/`PATH` for running the linter.
- Update `README.md` with CI instructions, local reproduction steps, and notes about the Codex Cloud environment files and alternative install method.
- Use explicit paths to the installed global tool in CI (`~/.dotnet/tools/udonsharp-lint`) and ensure the required runtime version is present before installing the linter.

### Testing

- The updated CI job `UdonSharp Lint` is configured to run the linter (`udonsharp-lint Packages/com.nekometer.esnya.inari-udon`) in GitHub Actions (workflow defined and validated). The linter invocation in CI is intended to pass when sources comply with the linter rules.
- The Codex Cloud `setup.sh` was exercised locally to verify it installs .NET SDK/runtime, installs the `tktco.UdonSharpLinter` tool, and that `dotnet --info` and `dotnet tool list --global` return expected results (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d631361148832a9b0c44cb0abb7da1)